### PR TITLE
Add script for Oura readiness trend insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# trackertest
+# Oura Insights App
+
+A small command line utility that analyzes your Oura Ring readiness data from a CSV export and provides a simple trend analysis.
+
+## Usage
+
+1. Export your readiness data as a CSV file from cloud.ouraring.com.
+2. Run the app: `python oura_app.py path/to/readiness.csv`
+
+The script compares the average readiness score of the last seven days with the previous week and prints whether your readiness has improved, declined, or remained stable.

--- a/oura_app.py
+++ b/oura_app.py
@@ -1,0 +1,56 @@
+import argparse
+import csv
+from typing import List
+
+
+def read_scores(path: str, column: str) -> List[int]:
+    """Read readiness scores from a CSV file."""
+    scores: List[int] = []
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            val = row.get(column)
+            if not val:
+                continue
+            try:
+                scores.append(int(float(val)))
+            except ValueError:
+                continue
+    return scores
+
+
+def calculate_trend(values: List[int]) -> float:
+    """Return the difference between the last 7 day mean and previous 7 day mean."""
+    if len(values) < 14:
+        raise ValueError("At least 14 values are required to compute trend")
+    recent = values[-7:]
+    previous = values[-14:-7]
+    return sum(recent) / 7 - sum(previous) / 7
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Analyze Oura Ring readiness trends from a CSV export"
+    )
+    parser.add_argument("csv_file", help="CSV file containing readiness scores")
+    parser.add_argument(
+        "--column", default="score", help="Column name holding the readiness score"
+    )
+    args = parser.parse_args()
+
+    scores = read_scores(args.csv_file, args.column)
+    if len(scores) < 14:
+        raise SystemExit("Not enough data to compute trend")
+
+    trend = calculate_trend(scores)
+    if trend > 0:
+        msg = "Your readiness score has improved over the past week."
+    elif trend < 0:
+        msg = "Your readiness score has declined over the past week."
+    else:
+        msg = "Your readiness score is stable week over week."
+    print(msg)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `oura_app.py`, a lightweight CLI that analyzes Oura Ring readiness scores from a CSV export and reports week-over-week trends
- document CSV-based usage in README

## Testing
- `python oura_app.py -h`
- `python oura_app.py sample.csv` (with a generated sample dataset)


------
https://chatgpt.com/codex/tasks/task_e_6898d30b5ae08328a615f473ca8963f4